### PR TITLE
Add dooing todo plugin with per-project support

### DIFF
--- a/config/plugins/notes/default.nix
+++ b/config/plugins/notes/default.nix
@@ -5,6 +5,7 @@
     ./qalc.nix
     ./wakatime.nix
     ./clipboard-image.nix
+    ./dooing.nix
     # ./diagram.nix  # Temporarily disabled due to terminal size error
     ./markview.nix
   ];

--- a/config/plugins/notes/dooing.nix
+++ b/config/plugins/notes/dooing.nix
@@ -1,0 +1,27 @@
+{pkgs, ...}: {
+  # https://github.com/atiladefreitas/dooing
+  extraPlugins = with pkgs; [
+    dooing
+  ];
+
+  extraConfigLua = ''
+    -- dooing ships a `plugin/dooing.vim` that calls `setup()` with the upstream
+    -- defaults, which would register `<leader>td`/`<leader>tD` on top of the
+    -- existing [T]oggle mappings. Claim the load guard and configure it here.
+    vim.g.loaded_dooing = 1
+
+    require('dooing').setup({
+      per_project = {
+        enabled = true,
+        default_filename = "dooing.json",
+        auto_gitignore = "prompt",
+      },
+      keymaps = {
+        -- Global mappings, the rest are buffer local to the todo window
+        toggle_window = "<leader>xd",
+        open_project_todo = "<leader>xp",
+        show_due_notification = "<leader>xu",
+      },
+    })
+  '';
+}

--- a/config/plugins/ui/which-key.nix
+++ b/config/plugins/ui/which-key.nix
@@ -43,6 +43,10 @@
           __unkeyed-1 = "<leader>o";
           group = "[O]verseer";
         }
+        {
+          __unkeyed-1 = "<leader>x";
+          group = "Dooing todos";
+        }
       ];
     };
   };

--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,22 @@
         "type": "github"
       }
     },
+    "dooing": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1786670297,
+        "narHash": "sha256-yoHr6Kl3oKwcQyNR+FvlkKHK6uHtLubUJLXIAhth2U8=",
+        "owner": "atiladefreitas",
+        "repo": "dooing",
+        "rev": "4c4ac78088cf462398a0206e79669936a184175f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "atiladefreitas",
+        "repo": "dooing",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -244,6 +260,7 @@
     "root": {
       "inputs": {
         "atone-nvim": "atone-nvim",
+        "dooing": "dooing",
         "flake-parts": "flake-parts",
         "git-hooks-nix": "git-hooks-nix",
         "go-nvim": "go-nvim",

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,10 @@
       url = "github:XXiaoA/atone.nvim";
       flake = false;
     };
+    dooing = {
+      url = "github:atiladefreitas/dooing";
+      flake = false;
+    };
   };
 
   outputs = {
@@ -128,7 +132,7 @@
 
         # Expose custom packages as overlay
         overlays.default = final: prev: {
-          inherit (self.packages.${prev.stdenv.hostPlatform.system}) go-nvim guihua-lua qalc-nvim primes-99 atone-nvim;
+          inherit (self.packages.${prev.stdenv.hostPlatform.system}) go-nvim guihua-lua qalc-nvim primes-99 atone-nvim dooing;
           overseer-nvim = self.packages.${prev.stdenv.hostPlatform.system}.overseer-nvim or prev.vimPlugins.overseer-nvim;
         };
       };

--- a/packages/dooing/package.nix
+++ b/packages/dooing/package.nix
@@ -1,0 +1,9 @@
+{
+  inputs,
+  vimUtils,
+}:
+vimUtils.buildVimPlugin {
+  pname = "dooing";
+  src = inputs.dooing;
+  version = inputs.dooing.shortRev;
+}


### PR DESCRIPTION
## Summary
Adds the dooing plugin to Kixvim, a todo/task management plugin with per-project support. This enables users to manage project-specific todo lists with automatic gitignore integration.

## Changes
- **New plugin configuration** (`config/plugins/notes/dooing.nix`): Sets up dooing with per-project todos enabled and custom keymaps under `<leader>x` prefix
- **Flake integration**: Added dooing as a flake input and exposed it through the default overlay
- **Package definition** (`packages/dooing/package.nix`): Created buildVimPlugin wrapper for dooing
- **Plugin registration**: Added dooing to the notes plugin category in `config/plugins/notes/default.nix`
- **Keybinding documentation**: Updated which-key configuration to document the new `<leader>x` group for dooing commands

## Implementation Details
- Prevents double initialization by setting `vim.g.loaded_dooing = 1` before calling setup, allowing custom configuration instead of using upstream defaults
- Configured keymaps:
  - `<leader>xd`: Toggle todo window
  - `<leader>xp`: Open project todo
  - `<leader>xu`: Show due notification
- Per-project todos stored in `dooing.json` with prompt-based gitignore handling

https://claude.ai/code/session_01J6UUGd9vB4xnJwMwTKpE3V